### PR TITLE
Mise à jour du test Cypress pour correspondre au titre de la page d'a…

### DIFF
--- a/frontend/cypress/e2e/test.cy.ts
+++ b/frontend/cypress/e2e/test.cy.ts
@@ -4,7 +4,7 @@ describe('Vue 3 App', () => {
   });
 
   it("Visite la page d'accueil", () => {
-    cy.contains('h1', 'Home');
+    cy.contains('h1', 'Bienvenue');
   });
 
   it('Visite la page de login', () => {


### PR DESCRIPTION
…ccueil

- Modification du test pour vérifier le titre "Bienvenue" au lieu de "Home"
- Alignement du test avec la personnalisation récente de la page d'accueil